### PR TITLE
Add catalog into connection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,6 +153,14 @@ If you do not specify ``aws_access_key_id`` and ``aws_secret_access_key`` using 
 
     awsathena+rest://:@athena.{region_name}.amazonaws.com:443/{schema_name}?s3_staging_dir={s3_staging_dir}&...
 
+Additional field
+^^^^^^^^^^^^^^^^
+You can specify ``catalog``:
+
+.. code:: text
+
+    awsathena+rest://:@athena.{region_name}.amazonaws.com:443/{catalog_name}.{schema_name}?s3_staging_dir={s3_staging_dir}&...
+
 Dialect & driver
 ^^^^^^^^^^^^^^^^
 

--- a/pyathena/sqlalchemy/base.py
+++ b/pyathena/sqlalchemy/base.py
@@ -1001,8 +1001,8 @@ class AthenaDialect(DefaultDialect):
             )
             if url.host
             else None,
-            "catalog_name": url.database.split("/")[0] if url.database and "." in url.database else "awsdatacatalog",
-            "schema_name": (url.database.split("/")[1] if "/" in url.database else url.database) if url.database else "default",
+            "catalog_name": url.database.split(".")[0] if url.database and "." in url.database else "awsdatacatalog",
+            "schema_name": (url.database.split(".")[1] if "." in url.database else url.database) if url.database else "default",
         }
         opts.update(url.query)
         if "verify" in opts:

--- a/pyathena/sqlalchemy/base.py
+++ b/pyathena/sqlalchemy/base.py
@@ -988,7 +988,7 @@ class AthenaDialect(DefaultDialect):
         # Connection string format:
         #   awsathena+rest://
         #   {aws_access_key_id}:{aws_secret_access_key}@athena.{region_name}.amazonaws.com:443/
-        #   {schema_name}?s3_staging_dir={s3_staging_dir}&...
+        #   {catalog_name}.{schema_name}?s3_staging_dir={s3_staging_dir}&...
         self._connect_options = self._create_connect_args(url)
         return cast(Tuple[str], tuple()), self._connect_options
 
@@ -1001,7 +1001,8 @@ class AthenaDialect(DefaultDialect):
             )
             if url.host
             else None,
-            "schema_name": url.database if url.database else "default",
+            "catalog_name": url.database.split("/")[0] if url.database and "." in url.database else "awsdatacatalog",
+            "schema_name": (url.database.split("/")[1] if "/" in url.database else url.database) if url.database else "default",
         }
         opts.update(url.query)
         if "verify" in opts:


### PR DESCRIPTION
Because the current superset and the connector, pyathena, don't support the concept of multicatalogs, this PR is to add a catalog in the connect string.

There are issues in unit tests from the dependency, `sqlalchemy`, the PR doesn't include unit tests. For instance,
```
AttributeError: 'NoneType' object has no attribute 'global_cleanup_assertions'
AttributeError: 'NoneType' object has no attribute '_current'
AttributeError: 'NoneType' object has no attribute 'Config'
AttributeError: 'NoneType' object has no attribute 'requirements'
```
